### PR TITLE
feat: チャットメッセージのコピー機能を追加 #31

### DIFF
--- a/viewer/static/css/style.css
+++ b/viewer/static/css/style.css
@@ -1429,6 +1429,106 @@ body {
     display: none;
 }
 
+/* ===== コピーボタンスタイル ===== */
+
+.copy-button {
+    background: none;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: var(--spacing-1);
+    border-radius: var(--border-radius-sm);
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+    margin-left: var(--spacing-2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    min-height: 24px;
+    opacity: 0;
+    transform: scale(0.9);
+}
+
+.copy-button:hover {
+    background-color: var(--bg-hover);
+    color: var(--text-primary);
+    transform: scale(1);
+    opacity: 1;
+}
+
+.copy-button:focus {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    opacity: 1;
+}
+
+.copy-button:active {
+    transform: scale(0.95);
+}
+
+/* ホバー時にコピーボタンを表示 */
+.chat-message:hover .copy-button,
+.chat-message:focus-within .copy-button {
+    opacity: 0.7;
+}
+
+.chat-message:hover .copy-button:hover,
+.copy-button:focus {
+    opacity: 1;
+}
+
+/* コピー成功・失敗フィードバック */
+.copy-button.copy-success {
+    color: var(--success, #22c55e);
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.copy-button.copy-error {
+    color: var(--error, #ef4444);
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+/* メッセージヘッダー内でのレイアウト調整 */
+.message-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+}
+
+.message-header .copy-button {
+    margin-left: auto;
+    margin-right: var(--spacing-1);
+}
+
+/* タッチデバイス対応 */
+@media (hover: none) and (pointer: coarse) {
+    .copy-button {
+        opacity: 0.6;
+        min-width: 32px;
+        min-height: 32px;
+        font-size: 1.1rem;
+    }
+
+    .copy-button:active {
+        opacity: 1;
+        background-color: var(--bg-hover);
+    }
+}
+
+/* ダークテーマ対応 */
+[data-theme="dark"] .copy-button {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .copy-button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: var(--text-primary);
+}
+
 /* レスポンシブ対応 */
 @media (max-width: 768px) {
     .log-converter-container {
@@ -1438,5 +1538,12 @@ body {
     .log-converter-btn {
         padding: var(--spacing-1) var(--spacing-3);
         font-size: var(--font-size-xs);
+    }
+
+    /* モバイルでコピーボタンを少し大きく */
+    .copy-button {
+        min-width: 28px;
+        min-height: 28px;
+        font-size: 1.05rem;
     }
 }

--- a/viewer/static/js/copy-utils.js
+++ b/viewer/static/js/copy-utils.js
@@ -1,0 +1,221 @@
+/**
+ * コピー機能ユーティリティ
+ * チャットメッセージのコピー機能を提供
+ */
+
+class CopyUtils {
+    /**
+     * テキストをクリップボードにコピー
+     * @param {string} text - コピーするテキスト
+     * @param {HTMLElement} button - コピーボタン要素（フィードバック表示用）
+     * @returns {Promise<boolean>} - コピー成功時true
+     */
+    static async copyToClipboard(text, button = null) {
+        try {
+            // Clipboard API を使用（モダンブラウザ）
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                console.log('テキストをクリップボードにコピーしました:', text.substring(0, 50) + '...');
+
+                if (button) {
+                    CopyUtils.showCopyFeedback(button, true);
+                }
+
+                return true;
+            } else {
+                // フォールバック: execCommand を使用（古いブラウザ）
+                return CopyUtils.fallbackCopy(text, button);
+            }
+        } catch (error) {
+            console.error('クリップボードへのコピーに失敗しました:', error);
+
+            if (button) {
+                CopyUtils.showCopyFeedback(button, false);
+            }
+
+            // フォールバック処理を試行
+            return CopyUtils.fallbackCopy(text, button);
+        }
+    }
+
+    /**
+     * フォールバックコピー処理（古いブラウザ対応）
+     * @param {string} text - コピーするテキスト
+     * @param {HTMLElement} button - コピーボタン要素
+     * @returns {boolean} - コピー成功時true
+     */
+    static fallbackCopy(text, button = null) {
+        try {
+            // 一時的なテキストエリアを作成
+            const textArea = document.createElement('textarea');
+            textArea.value = text;
+            textArea.style.position = 'fixed';
+            textArea.style.left = '-999999px';
+            textArea.style.top = '-999999px';
+            document.body.appendChild(textArea);
+
+            // テキストを選択してコピー
+            textArea.focus();
+            textArea.select();
+
+            const successful = document.execCommand('copy');
+            document.body.removeChild(textArea);
+
+            if (successful) {
+                console.log('フォールバック方式でコピー成功');
+                if (button) {
+                    CopyUtils.showCopyFeedback(button, true);
+                }
+                return true;
+            } else {
+                throw new Error('execCommand failed');
+            }
+        } catch (error) {
+            console.error('フォールバックコピーも失敗しました:', error);
+            if (button) {
+                CopyUtils.showCopyFeedback(button, false);
+            }
+            return false;
+        }
+    }
+
+    /**
+     * コピー操作のビジュアルフィードバック
+     * @param {HTMLElement} button - コピーボタン要素
+     * @param {boolean} success - 成功時true、失敗時false
+     */
+    static showCopyFeedback(button, success) {
+        if (!button) return;
+
+        const originalIcon = button.textContent;
+        const originalTitle = button.title;
+
+        if (success) {
+            // 成功時のフィードバック
+            button.textContent = 'コピー済み';
+            button.title = 'コピーしました！';
+            button.classList.add('copy-success');
+
+            // 2秒後に元に戻す
+            setTimeout(() => {
+                button.textContent = originalIcon;
+                button.title = originalTitle;
+                button.classList.remove('copy-success');
+            }, 2000);
+        } else {
+            // 失敗時のフィードバック
+            button.textContent = 'エラー';
+            button.title = 'コピーに失敗しました';
+            button.classList.add('copy-error');
+
+            // 2秒後に元に戻す
+            setTimeout(() => {
+                button.textContent = originalIcon;
+                button.title = originalTitle;
+                button.classList.remove('copy-error');
+            }, 2000);
+        }
+    }
+
+    /**
+     * メッセージ要素からテキスト内容を抽出
+     * @param {HTMLElement} messageElement - メッセージ要素
+     * @returns {string} - 抽出されたテキスト
+     */
+    static extractMessageText(messageElement) {
+        const contentElement = messageElement.querySelector('.message-content');
+        if (!contentElement) {
+            return '';
+        }
+
+        // HTMLタグを除去してプレーンテキストを取得
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = contentElement.innerHTML;
+
+        // <br>タグを改行文字に変換
+        tempDiv.innerHTML = tempDiv.innerHTML.replace(/<br\s*\/?>/gi, '\n');
+
+        // リンクは URL として保持
+        const links = tempDiv.querySelectorAll('a');
+        links.forEach(link => {
+            link.textContent = link.href;
+        });
+
+        return tempDiv.textContent || tempDiv.innerText || '';
+    }
+
+    /**
+     * コピーボタンのHTML要素を作成
+     * @param {string} messageText - コピー対象のテキスト
+     * @param {string} messageIndex - メッセージインデックス（一意性確保用）
+     * @returns {string} - コピーボタンのHTML
+     */
+    static createCopyButtonHTML(messageText, messageIndex) {
+        return `<button class="copy-button"
+                        data-message-index="${messageIndex}"
+                        title="クリップボードにコピー"
+                        aria-label="このメッセージをクリップボードにコピーします"
+                        tabindex="0">コピー</button>`;
+    }
+
+    /**
+     * コピーボタンのイベントリスナーを設定
+     * @param {HTMLElement} container - メッセージコンテナ要素
+     */
+    static attachCopyListeners(container) {
+        if (!container) return;
+
+        const copyButtons = container.querySelectorAll('.copy-button');
+
+        copyButtons.forEach(button => {
+            // クリックイベント
+            button.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                CopyUtils.handleCopyClick(button);
+            });
+
+            // キーボードイベント（アクセシビリティ対応）
+            button.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    CopyUtils.handleCopyClick(button);
+                }
+            });
+        });
+    }
+
+    /**
+     * コピーボタンクリック時の処理
+     * @param {HTMLElement} button - クリックされたボタン
+     */
+    static handleCopyClick(button) {
+        // 親のメッセージ要素を探す
+        const messageElement = button.closest('.chat-message');
+        if (!messageElement) {
+            console.error('メッセージ要素が見つかりません');
+            return;
+        }
+
+        // メッセージテキストを抽出
+        const messageText = CopyUtils.extractMessageText(messageElement);
+
+        if (!messageText.trim()) {
+            console.warn('コピーするテキストが見つかりません');
+            CopyUtils.showCopyFeedback(button, false);
+            return;
+        }
+
+        // コピー実行
+        CopyUtils.copyToClipboard(messageText, button);
+
+        // 統計情報があれば送信（オプション）
+        if (window.uiManager && typeof window.uiManager.showNotification === 'function') {
+            // 成功通知は控えめに（ボタンのフィードバックで十分）
+        }
+    }
+}
+
+// グローバルに公開
+window.CopyUtils = CopyUtils;

--- a/viewer/static/js/realtime-client.js
+++ b/viewer/static/js/realtime-client.js
@@ -350,6 +350,11 @@ class RealtimeClient {
 
         this.elements.messageArea.appendChild(container);
 
+        // コピーボタンのイベントリスナーを追加
+        if (window.CopyUtils) {
+            window.CopyUtils.attachCopyListeners(container);
+        }
+
         // もっと読み込みボタンの表示制御
         this.updateLoadMoreButton();
 
@@ -376,6 +381,11 @@ class RealtimeClient {
                         <span class="message-role">${roleText}</span>
                     </div>
                     <span class="message-timestamp">${timestamp}</span>
+                    <button class="copy-button"
+                            data-message-index="${messageNumber}"
+                            title="クリップボードにコピー"
+                            aria-label="このメッセージをクリップボードにコピーします"
+                            tabindex="0">コピー</button>
                 </div>
                 <div class="message-content">
                     ${this.formatMessageContent(message.content)}
@@ -423,6 +433,12 @@ class RealtimeClient {
         messages.forEach(msg => {
             const messageElement = this.createMessageElement(msg, messageNumber);
             container.appendChild(messageElement);
+
+            // 新しいメッセージにコピーボタンのイベントリスナーを追加
+            if (window.CopyUtils) {
+                window.CopyUtils.attachCopyListeners(messageElement);
+            }
+
             messageNumber++;
         });
 

--- a/viewer/static/js/ui-manager.js
+++ b/viewer/static/js/ui-manager.js
@@ -325,6 +325,11 @@ class UIManager {
                             <span class="message-role">${roleName}</span>
                         </span>
                         <span class="message-timestamp">${timestamp}</span>
+                        <button class="copy-button"
+                                data-message-index="${index}"
+                                title="クリップボードにコピー"
+                                aria-label="このメッセージをクリップボードにコピーします"
+                                tabindex="0">コピー</button>
                     </div>
                     <div class="message-content">${this.formatMessageContent(
                         message.content
@@ -336,6 +341,11 @@ class UIManager {
         });
 
         this.elements.messageArea.appendChild(chatContainer);
+
+        // コピーボタンのイベントリスナーを追加
+        if (window.CopyUtils) {
+            window.CopyUtils.attachCopyListeners(chatContainer);
+        }
 
         // 最後のメッセージまでスクロール（確実にDOM更新後に実行）
         this.scrollToBottom();

--- a/viewer/templates/index.html
+++ b/viewer/templates/index.html
@@ -196,6 +196,7 @@
     <script src="https://cdn.socket.io/4.5.0/socket.io.min.js"></script>
     <script src="/static/js/scroll-utils.js"></script>
     <script src="/static/js/virtual-scroller.js"></script>
+    <script src="/static/js/copy-utils.js"></script>
     <script src="/static/js/api-client.js"></script>
     <script src="/static/js/ui-manager.js"></script>
     <script src="/static/js/realtime-client.js"></script>


### PR DESCRIPTION
## 概要
チャットメッセージにコピーボタンを追加し、メッセージ内容をクリップボードにコピーできる機能を実装しました。

## 変更点

### 新規作成ファイル
- `copy-utils.js`: 共通コピー機能ユーティリティクラス
  - Clipboard API使用（モダンブラウザ対応）
  - execCommandフォールバック（古いブラウザ対応）
  - 視覚的フィードバック機能
  - アクセシビリティ対応

### 修正ファイル
- `ui-manager.js`: データベースモード用コピーボタン追加
- `realtime-client.js`: リアルタイムモード用コピーボタン追加
- `style.css`: コピーボタンスタイル・ホバーエフェクト追加
- `index.html`: copy-utils.jsスクリプト読み込み追加

### 機能仕様
- データベースモード・リアルタイムモード両対応
- ホバー時にコピーボタン表示
- 成功時「コピー済み」、失敗時「エラー」フィードバック
- アクセシビリティ対応（aria-label、キーボード操作）
- レスポンシブデザイン・タッチデバイス対応
- 日本語UIでユーザビリティ向上

## テスト
- ✅ 両モードでコピーボタン動作確認
- ✅ Clipboard API・execCommandフォールバック動作確認
- ✅ 視覚的フィードバック表示確認
- ✅ キーボード操作（Enter/Space）動作確認
- ✅ レスポンシブデザイン確認
- ✅ 構文エラー・型チェック合格
- ✅ アクセシビリティ検証合格

fixes #31